### PR TITLE
Add a non file resource spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Style/TrailingCommaInHashLiteral:
 
 Metrics/BlockLength:
   Max: 35
+  ExcludedMethods: [ 'describe' ]
 
 Metrics/MethodLength:
   Max: 25

--- a/spec/puppet-lint/plugins/no_file_path_attribute_spec.rb
+++ b/spec/puppet-lint/plugins/no_file_path_attribute_spec.rb
@@ -3,6 +3,22 @@ require 'spec_helper'
 describe 'no_file_path_attribute' do
   let(:msg) { 'file resources should not have a path attribute. Use the title instead' }
 
+  context 'when the manifest has no file resources' do
+    let(:code) do
+      <<-TEST_CLASS
+        class no_file_resource {
+          host { 'syslog':
+            ip => '10.10.10.10',
+          }
+        }
+      TEST_CLASS
+    end
+
+    it 'does not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'when the file resources has a full path title' do
     let(:code) do
       <<-EXAMPLE_CLASS


### PR DESCRIPTION
This tests that the plugin does not throw errors if the manifest lacks
`file` resources.